### PR TITLE
Add default_command

### DIFF
--- a/lib/devcenter/cli.rb
+++ b/lib/devcenter/cli.rb
@@ -50,3 +50,5 @@ command :preview do |c|
     Devcenter::Commands::Preview.run(args[0], options.host, options.port)
   end
 end
+
+default_command :help


### PR DESCRIPTION
Show `:help` when ran with no commands:

```
devcenter-cli git:master ❯ devcenter                                                                                                                
  NAME:

    devcenter

  DESCRIPTION:

    CLI to interact with Heroku's Dev Center

  COMMANDS:

    help                 Display global or [command] help documentation.                
    open                 Open the article with the given slug in the default browser            
    preview              Opens a live preview for a given article file          
    pull   
...
...
```
