### PR TITLE
Force polling for change events

### DIFF
--- a/lib/devcenter/previewer/file_listener.rb
+++ b/lib/devcenter/previewer/file_listener.rb
@@ -6,7 +6,7 @@ module Devcenter::Previewer
     def initialize(file_path, callback)
       dir = File.dirname(file_path)
       basename = File.basename(file_path)
-      @listener = Listen.to(dir)
+      @listener = Listen.to(dir, force_polling: true)
       @listener.filter(%r{#{basename}})
       @listener.change(&callback)
     end


### PR DESCRIPTION
Possible "solution" to #10 by explictly using polling, instead of falling back
on it, which issues the warning message. 
