### PR TITLE
Bump `json` gem; be more optimistic about versioning

### DIFF
--- a/devcenter.gemspec
+++ b/devcenter.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('tilt', '~>1.3.3')
   gem.add_runtime_dependency('rack-highlighter', '~>0.2.0')
   gem.add_runtime_dependency('devcenter-parser', '~>1.4.2')
-  gem.add_runtime_dependency('netrc', '~>0.7.7')
+  gem.add_runtime_dependency('netrc', '~>0.10', '>= 0.10.2')
 end

--- a/devcenter.gemspec
+++ b/devcenter.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w{ lib }
   gem.add_runtime_dependency('listen', '~> 1.3.1')
   gem.add_runtime_dependency('commander', '~> 4.1.3')
-  gem.add_runtime_dependency('json', '~>1.7.6')
+  gem.add_runtime_dependency('json', '~>1.8', '>= 1.8.2')
   gem.add_runtime_dependency('excon', '~>0.15.4')
   gem.add_runtime_dependency('launchy', '~>2.1.0')
   gem.add_runtime_dependency('coderay', '~>1.0.8')


### PR DESCRIPTION
`json` 1.7.6 won't build under Ruby 2.2.0 so let's bump it up to the
latest version.

Also be more optimistic on dependencies so that we can pick up new
variants of 1.8 as they're released.

/cc @raul