### PR TITLE
Support `.netrc.gpg` like the Toolbelt

### DIFF
--- a/lib/devcenter/helpers.rb
+++ b/lib/devcenter/helpers.rb
@@ -54,10 +54,19 @@ module Devcenter::Helpers
   end
 
   def get_oauth_token
-    netrc = Netrc.read
+    netrc = Netrc.read(netrc_path)
     user, token = netrc['api.heroku.com']
     abort 'Heroku credentials not found. Execute "heroku login" to create them.' unless token
     token
   end
 
+  def netrc_path
+    default = Netrc.default_path
+    encrypted = default + ".gpg"
+    if File.exists?(encrypted)
+      encrypted
+    else
+      default
+    end
+  end
 end


### PR DESCRIPTION
This reads `.netrc.gpg` if available and falls back to `.netrc` if not
in the same way that the Toolbelt currently works.

(Tested on my box.)

/cc @raul