### PR TITLE
Add to Components Inventory, part 1

### DIFF
--- a/.github/workflows/sync_component_metadata.yml
+++ b/.github/workflows/sync_component_metadata.yml
@@ -1,0 +1,25 @@
+name: "Send data to Components Inventory"
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+    paths:
+      - ".heroku/components-inventory/*.json"
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    paths:
+      - ".heroku/components-inventory/*.json"
+jobs:
+  action:
+    runs-on: sfdc-hk-ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Send data to Components Inventory
+        uses: heroku/components-action@main
+        with:
+          COMPONENTS_GHA_APP_ID: ${{ secrets.COMPONENTS_GHA_APP_ID}}
+          COMPONENTS_GHA_APP_PRIVATE_KEY: ${{ secrets.COMPONENTS_GHA_APP_PRIVATE_KEY}}
+          COMPONENTS_GHA_JSON_TOKEN: ${{ secrets.COMPONENTS_GHA_JSON_TOKEN}}


### PR DESCRIPTION
This PR is the first step to add this project to the Heroku Components Inventory. It uses a new process which uses JSON files living in Github repositories as the source of truth for components information (see DR for details and reason, see migration plan for project planning aspects).

For questions regarding the migration or this process, see #proj-heroku-components-inventory-migration in Slack.