### PR TITLE
Changing File.exists? for File.exist?

### DIFF
--- a/lib/devcenter/commands/preview.rb
+++ b/lib/devcenter/commands/preview.rb
@@ -12,7 +12,7 @@ module Devcenter::Commands
 
     def validate
       empty_slug = @slug.nil? || @slug.to_s.strip.empty?
-      file_exists = !empty_slug && File.exists?(@md_path)
+      file_exists = !empty_slug && File.exist?(@md_path)
       if empty_slug
         @validation_errors << 'Please provide an article slug'
       elsif !file_exists

--- a/lib/devcenter/commands/pull.rb
+++ b/lib/devcenter/commands/pull.rb
@@ -24,7 +24,7 @@ module Devcenter::Commands
       file_path = md_file_path(@slug)
 
       unless @force_overwrite
-        cancel_save = File.exists?(file_path) && !agree("The file #{file_path} already exists - overwrite? (yes/no)")
+        cancel_save = File.exist?(file_path) && !agree("The file #{file_path} already exists - overwrite? (yes/no)")
         return if cancel_save
       end
 

--- a/lib/devcenter/commands/push.rb
+++ b/lib/devcenter/commands/push.rb
@@ -10,7 +10,7 @@ module Devcenter::Commands
 
     def validate
       empty_slug = @slug.nil? || @slug.to_s.strip.empty?
-      file_exists = !empty_slug && File.exists?(@md_path)
+      file_exists = !empty_slug && File.exist?(@md_path)
       if empty_slug
         @validation_errors << 'Please provide an article slug'
       elsif !file_exists

--- a/lib/devcenter/helpers.rb
+++ b/lib/devcenter/helpers.rb
@@ -62,7 +62,7 @@ module Devcenter::Helpers
   def netrc_path
     default = Netrc.default_path
     encrypted = default + ".gpg"
-    if File.exists?(encrypted)
+    if File.exist?(encrypted)
       encrypted
     else
       default

--- a/lib/devcenter/previewer/web_app.rb
+++ b/lib/devcenter/previewer/web_app.rb
@@ -45,7 +45,7 @@ module Devcenter::Previewer
     get '/:slug' do
       log "Local article requested: #{params[:slug]}"
       src_path = File.join(Dir.pwd, "#{params[:slug]}.md")
-      if File.exists?(src_path)
+      if File.exist?(src_path)
         log "Parsing"
         @article = Devcenter::ArticleFile.read(src_path)
         @page_title = @article.metadata.title


### PR DESCRIPTION
File.exists? is deprecated since Ruby 2.1.0 and was finally removed on Ruby 3.2.0
This aims to make this gem compatible with Ruby 3.2.0 and newer versions.