### PR TITLE
bump version to 1.3.0

### DIFF
--- a/lib/devcenter/version.rb
+++ b/lib/devcenter/version.rb
@@ -1,3 +1,3 @@
 module Devcenter
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.3.0'.freeze
 end


### PR DESCRIPTION
Bumps the gem version to 1.3.0 in preparation for a release that includes #42 . 