### PR TITLE
Update string encode to not place newlines

### DIFF
--- a/lib/devcenter/client.rb
+++ b/lib/devcenter/client.rb
@@ -96,7 +96,7 @@ module Devcenter
     end
 
     def encode64(str)
-      Base64.encode64(str).strip
+      Base64.strict_encode64(str)
     end
   end
 

--- a/lib/devcenter/version.rb
+++ b/lib/devcenter/version.rb
@@ -1,3 +1,3 @@
 module Devcenter
-  VERSION = '1.3.0'.freeze
+  VERSION = '1.3.1'.freeze
 end


### PR DESCRIPTION
The current form of base64 string encoding we use for encoding auth tokens worked great until we prepended `HRKU-` to the tokens in `.netrc` from which devcenter-cli pulls from. Since the strings are now > 60 characters, the legacy `Base64.encode64` adds `\n` after every 60 characters because #OldComputers and that makes Excon grumpy. Our implementation, more specifically, was `Base64.encode64(str).strip`, in which `.strip` doesn't strip machine characters like `\n`, just things like whitespace.

We should swap that out for the newer, doesn't-care-about-old-computer-feelings `Base64.strict_encode64(str)`. This will do the same strip-encode all in one pass in a more reliable fashion.

Reported in Slack: https://salesforce-internal.slack.com/archives/C1P5PLSUU/p1755537753762739

WI: https://gus.lightning.force.com/a07EE00002KKbN9YAL