### PR TITLE
chore: bump to v2.0.0 and refresh readme after publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ npm install -g @heroku-cli/plugin-devcenter
 $ heroku COMMAND
 running command...
 $ heroku (--version)
-@heroku-cli/plugin-devcenter/1.3.1 darwin-arm64 node-v24.14.0
+@heroku-cli/plugin-devcenter/2.0.0 darwin-arm64 node-v24.14.0
 $ heroku --help [COMMAND]
 USAGE
   $ heroku COMMAND
@@ -51,7 +51,7 @@ DESCRIPTION
   open a Dev Center article in the browser (uses Heroku credentials for private or draft content when available)
 ```
 
-_See code: [src/commands/devcenter/open.ts](https://github.com/heroku/devcenter-cli/blob/v1.3.1/src/commands/devcenter/open.ts)_
+_See code: [src/commands/devcenter/open.ts](https://github.com/heroku/devcenter-cli/blob/v2.0.0/src/commands/devcenter/open.ts)_
 
 ## `heroku devcenter:preview SLUG`
 
@@ -75,7 +75,7 @@ DESCRIPTION
   preview a local Dev Center article in the browser with live reload
 ```
 
-_See code: [src/commands/devcenter/preview.ts](https://github.com/heroku/devcenter-cli/blob/v1.3.1/src/commands/devcenter/preview.ts)_
+_See code: [src/commands/devcenter/preview.ts](https://github.com/heroku/devcenter-cli/blob/v2.0.0/src/commands/devcenter/preview.ts)_
 
 ## `heroku devcenter:pull SLUGORURL`
 
@@ -98,7 +98,7 @@ DESCRIPTION
   save a local copy of a Dev Center article
 ```
 
-_See code: [src/commands/devcenter/pull.ts](https://github.com/heroku/devcenter-cli/blob/v1.3.1/src/commands/devcenter/pull.ts)_
+_See code: [src/commands/devcenter/pull.ts](https://github.com/heroku/devcenter-cli/blob/v2.0.0/src/commands/devcenter/pull.ts)_
 
 ## `heroku devcenter:push SLUG`
 
@@ -118,7 +118,7 @@ DESCRIPTION
   update a Dev Center article from a local markdown file
 ```
 
-_See code: [src/commands/devcenter/push.ts](https://github.com/heroku/devcenter-cli/blob/v1.3.1/src/commands/devcenter/push.ts)_
+_See code: [src/commands/devcenter/push.ts](https://github.com/heroku/devcenter-cli/blob/v2.0.0/src/commands/devcenter/push.ts)_
 <!-- commandsstop -->
 
 ## Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@heroku-cli/plugin-devcenter",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@heroku-cli/plugin-devcenter",
-      "version": "1.3.1",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "@heroku-cli/command": "^13.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@heroku-cli/plugin-devcenter",
   "description": "Heroku CLI plugin to interact with Heroku Dev Center",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "author": "Heroku",
   "type": "module",
   "license": "ISC",


### PR DESCRIPTION
## Summary

Bumps the package to **2.0.0** in `package.json` and `package-lock.json`, and updates the README usage sample and “See code” links to **v2.0.0** so docs match the published npm release.

## Type of Change

- [ ] **fix**: Bug fix or issue (patch semvar update)
- [ ] **feat**: Introduces a new feature to the codebase (minor semvar update)
- [ ] **perf**: Performance improvement
- [x] **docs**: Documentation only changes
- [ ] **tests**: Adding missing tests or correcting existing tests
- [x] **chore**: Code cleanup tasks, dependency updates, or other changes

*(Version bump is **chore**; README edits are **docs** — pick one primary box or leave both checked as above.)*

## Verification

CI Passes

Confirm `package.json` / lockfile version **2.0.0** and README references **v2.0.0** tags/links.

## Additional Context

This PR merges into **`feat/ruby-to-typescript`** (not `main`). It only aligns repo metadata and generated/readme docs with the post-publish **2.0.0** release; it does not expand the Ruby→TypeScript migration itself.

## Related Issue

Closes [W-20888419](https://gus.lightning.force.com/a07EE00002SqlSBYAZ)